### PR TITLE
feat: add Admin home page and its respective components

### DIFF
--- a/frontend/CareConnect/src/App.jsx
+++ b/frontend/CareConnect/src/App.jsx
@@ -1,3 +1,4 @@
+import AdminHome from "./pages/admin/AdminHome";
 import Home from "./pages/home/Home";
 
 
@@ -6,7 +7,8 @@ function App() {
 
   return (
     <>
-      <Home />
+      {/* <Home /> */}
+      <AdminHome />
     </>
   )
 }

--- a/frontend/CareConnect/src/components/layout/Header.jsx
+++ b/frontend/CareConnect/src/components/layout/Header.jsx
@@ -2,9 +2,9 @@ import IconRol from "./../common/IconRol";
 import LogOutButton from "./../common/LogOutButton"
 const Header = ({ rol }) => {
     const portalRol = {
-        family: "familiar",
-        admin: "de admin",
-        caregivers: "cuidadores",
+        family: "Familiar",
+        admin: "Administrador",
+        caregivers: "Cuidador",
     };
     return (
         <header className="bg-bg-secondary border-b border-border sticky top-0 z-10 shadow-sm">
@@ -20,7 +20,7 @@ const Header = ({ rol }) => {
                             CareConnect
                         </h2>
                         <p className="font-body text-f-secondary text-sm">
-                            portal {portalRol[rol]}
+                            Portal {portalRol[rol]}
                         </p>
                     </div>
                 </div>

--- a/frontend/CareConnect/src/index.css
+++ b/frontend/CareConnect/src/index.css
@@ -20,6 +20,7 @@ body {
   --color-page-caregivers-hover: #F0FDF4;
   --color-page-login: #4F39F6;
   --color-page-admin: #155DFC;
+  --color-page-reports: #FF8A00;
 
   --color-border: #E5E5E5;
   

--- a/frontend/CareConnect/src/pages/admin/AdminHome.jsx
+++ b/frontend/CareConnect/src/pages/admin/AdminHome.jsx
@@ -1,0 +1,73 @@
+import { Users, Activity, UsersRound, FileText } from 'lucide-react';
+import Header from '../../components/layout/Header';
+import Sidebar from './components/Sidebar';
+import MetricCard from './components/MetricCard';
+
+const AdminHome = () => {
+    const metrics = [
+        {
+            id: 1,
+            title: 'Total Pacientes',
+            value: '4',
+            icon: <Users size={24} />,
+            iconBgClass: 'bg-page-admin',
+            iconColorClass: 'text-white'
+        },
+        {
+            id: 2,
+            title: 'Cuidadores Activos',
+            value: '4',
+            icon: <Activity size={24} />,
+            iconBgClass: 'bg-page-caregivers',
+            iconColorClass: 'text-white'
+        },
+        {
+            id: 3,
+            title: 'Familias registradas',
+            value: '4',
+            icon: <UsersRound size={24} />,
+            iconBgClass: 'bg-page-family',
+            iconColorClass: 'text-white'
+        },
+        {
+            id: 4,
+            title: 'Informes pendientes',
+            value: '4',
+            icon: <FileText size={24} />,
+            iconBgClass: 'bg-page-reports',
+            iconColorClass: 'text-white'
+        }
+    ];
+
+    return (
+        <div className="min-h-screen bg-bg-primary flex flex-col">
+            {/* Header - Full Width at Top */}
+            <Header rol="admin" />
+
+            {/* Content Area with Sidebar */}
+            <div className="flex flex-1">
+                {/* Sidebar */}
+                <Sidebar activeItem="inicio" />
+
+                {/* Main Content */}
+                <main className="flex-1 p-8">
+                    {/* Metrics Grid */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl ml-auto">
+                        {metrics.map((metric) => (
+                            <MetricCard
+                                key={metric.id}
+                                title={metric.title}
+                                value={metric.value}
+                                icon={metric.icon}
+                                iconBgClass={metric.iconBgClass}
+                                iconColorClass={metric.iconColorClass}
+                            />
+                        ))}
+                    </div>
+                </main>
+            </div>
+        </div>
+    );
+};
+
+export default AdminHome;

--- a/frontend/CareConnect/src/pages/admin/components/MetricCard.jsx
+++ b/frontend/CareConnect/src/pages/admin/components/MetricCard.jsx
@@ -1,0 +1,17 @@
+const MetricCard = ({ title, value, icon, iconBgClass, iconColorClass }) => {
+    return (
+        <div className="bg-bg-secondary border border-border rounded-2xl p-6 flex items-center justify-between hover:shadow-md transition-shadow">
+            <div>
+                <p className="font-body text-f-secondary text-sm mb-1">{title}</p>
+                <p className="font-heading text-f-primary text-4xl font-bold">{value}</p>
+            </div>
+            <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${iconBgClass}`}>
+                <div className={iconColorClass}>
+                    {icon}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default MetricCard;

--- a/frontend/CareConnect/src/pages/admin/components/Sidebar.jsx
+++ b/frontend/CareConnect/src/pages/admin/components/Sidebar.jsx
@@ -1,0 +1,40 @@
+import { Home, Users, UserCircle, FileText, Heart } from 'lucide-react';
+
+const Sidebar = ({ activeItem = 'inicio' }) => {
+    const menuItems = [
+        { id: 'inicio', label: 'Inicio', icon: Home },
+        { id: 'usuarios', label: 'Usuarios', icon: Users },
+        { id: 'pacientes', label: 'Pacientes', icon: UserCircle },
+        { id: 'reportes', label: 'Reportes', icon: FileText },
+        { id: 'cuidadores', label: 'Cuidadores', icon: Heart },
+    ];
+
+    return (
+        <aside className="w-64 bg-bg-secondary border-r border-border flex flex-col">
+            <nav className="flex-1 px-3 py-6">
+                <ul className="space-y-2">
+                    {menuItems.map((item) => {
+                        const Icon = item.icon;
+                        const isActive = activeItem === item.id;
+
+                        return (
+                            <li key={item.id}>
+                                <button
+                                    className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-body text-sm transition-colors ${isActive
+                                        ? 'bg-page-admin text-white font-medium'
+                                        : 'text-f-secondary hover:bg-bg-tertiary hover:text-f-primary'
+                                        }`}
+                                >
+                                    <Icon size={18} />
+                                    <span>{item.label}</span>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </nav>
+        </aside>
+    );
+};
+
+export default Sidebar;


### PR DESCRIPTION
# 🔀 Pull Request Template – Frontend

Usar este template para **todos los Pull Requests del equipo frontend**.

---

## 🧩 ¿Qué se hizo?

Describí brevemente la funcionalidad implementada:

* Se creó la página de inicio del **Portal de Administrador** (`AdminHome`).
* Se implementó el componente `Sidebar` con la navegación requerida (Inicio, Usuarios, Pacientes, Reportes, Cuidadores).
* Se creó el componente reutilizable `MetricCard` para mostrar estadísticas con iconos y colores dinámicos.
* Se ajustó el componente `Header` para soportar el título "Portal Administrador" y mostrar correctamente los roles.
* Se agregaron variables de color faltantes en `index.css` (ej. `--color-page-reports`).


---

## 🖥️ Pantallas / Componentes afectados

Indicar qué partes del front se tocaron:

* **Pantalla:** `src/pages/admin/AdminHome.jsx`
* **Componentes:**
    * `src/pages/admin/components/Sidebar.jsx`
    * `src/pages/admin/components/MetricCard.jsx`
    * `src/components/layout/Header.jsx`
* **Estilos:** `src/index.css`

---

## 🧪 ¿Cómo probarlo?

Pasos claros para testear la feature:

1. Levantar el proyecto con `npm run dev`.
2. Ir a `http://localhost:5173` (Ir a `App.jsx` y cambiar a `<AdminHome />`).
3. Verificar la estructura del layout: Header arriba (full width), Sidebar a la izquierda, contenido a la derecha.
4. Verificar que se muestren las 4 tarjetas de métricas con sus iconos y colores correspondientes:
    * Total Pacientes (Azul)
    * Cuidadores Activos (Verde)
    * Familias registradas (Morado)
    * Informes pendientes (Naranja)
5. Verificar que el Header diga "CareConnect" y "Portal Administrador".

---

## 📸 Capturas (si aplica)

Adjuntar screenshots o GIFs si es UI.
![*(Adjuntar captura del Home Admin aquí)*](https://res.cloudinary.com/dhrtwfd13/image/upload/v1771358836/home_admin_fsnttd.jpg)

---

## ⚠️ Consideraciones

* ¿Hay algo a tener en cuenta?
    * Se agregó un nuevo color `--color-page-reports` en `index.css`.
    * Las `MetricCard` usan clases de Tailwind para los colores de fondo y texto, basándose en la paleta global.
* ¿Quedó algo pendiente?
    * La navegación del Sidebar es visual, aún no tiene react-router conectado a rutas reales.

---

## ✅ Checklist

* [x] Probé la funcionalidad localmente
* [x] No rompí otras pantallas
* [x] El PR es solo de esta feature
* [x] El código es legible y ordenado

---