### PR TITLE
Feature/frontend adminhome data flow

### DIFF
--- a/frontend/CareConnect/src/App.jsx
+++ b/frontend/CareConnect/src/App.jsx
@@ -5,17 +5,20 @@ import AdminUsers from "./pages/admin/AdminUsers";
 import Home from "./pages/home/Home";
 import Family from "./pages/family/Family";
 import Caregivers from "./pages/caregiver/Caregivers";
+import { ToastContainer } from "react-toastify";
+
 
 function App() {
 
 
   return (
     <>
+      <ToastContainer position="top-right" autoClose={3000} />
       {/* <Home /> */}
-      {/* <AdminHome /> */}
+      <AdminHome />
       {/* <AdminUsers /> */}
       {/* <Family /> */}
-      <Caregivers />
+      {/* <Caregivers /> */}
       {/* <AdminPatients /> */}
       {/* <AdminCaregivers /> */}
     </>

--- a/frontend/CareConnect/src/components/common/EmptyState.jsx
+++ b/frontend/CareConnect/src/components/common/EmptyState.jsx
@@ -1,0 +1,29 @@
+/**
+ * EmptyState – presentational component.
+ * Shown when data is null or a list is empty.
+ * @param {string} [message] - Optional custom message.
+ */
+const EmptyState = ({ message = "No hay datos disponibles" }) => {
+    return (
+        <div className="flex flex-col items-center justify-center w-full py-16 text-f-secondary">
+            <svg
+                className="w-12 h-12 mb-4 opacity-40"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+            >
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M9 17v-2a4 4 0 014-4h0a4 4 0 014 4v2M9 17H5a2 2 0 01-2-2v-1a7 7 0 0114 0v1a2 2 0 01-2 2h-4z"
+                />
+            </svg>
+            <p className="font-body text-sm">{message}</p>
+        </div>
+    );
+};
+
+export default EmptyState;

--- a/frontend/CareConnect/src/components/common/LoadingSpinner.jsx
+++ b/frontend/CareConnect/src/components/common/LoadingSpinner.jsx
@@ -1,0 +1,51 @@
+/**
+ * LoadingSpinner – presentational component.
+ * Displays a centered animated spinner while async operations are in progress.
+ * @param {string} [message] - Optional text displayed below the spinner.
+ * @param {string} [size] - "sm" | "md" | "lg". Defaults to "md".
+ */
+const LoadingSpinner = ({ message = "", size = "md" }) => {
+    const sizes = {
+        sm: { outer: "w-10 h-10", middle: "w-6 h-6", dot: "w-2 h-2" },
+        md: { outer: "w-16 h-16", middle: "w-10 h-10", dot: "w-3 h-3" },
+        lg: { outer: "w-24 h-24", middle: "w-16 h-16", dot: "w-4 h-4" },
+    };
+
+    const s = sizes[size] ?? sizes.md;
+
+    return (
+        <div className="flex flex-col items-center justify-center w-full py-16 gap-5">
+
+            {/* Spinner stack */}
+            <div className="relative flex items-center justify-center">
+
+                {/* Outer ring – slow, clockwise */}
+                <div
+                    className={`absolute ${s.outer} rounded-full border-4 border-transparent border-t-page-admin border-r-page-admin opacity-80 animate-spin`}
+                    style={{ animationDuration: "1.2s" }}
+                />
+
+                {/* Middle ring – faster, counter-clockwise */}
+                <div
+                    className={`absolute ${s.middle} rounded-full border-4 border-transparent border-b-page-login border-l-page-login opacity-50 animate-spin`}
+                    style={{ animationDuration: "0.8s", animationDirection: "reverse" }}
+                />
+
+                {/* Pulsing center dot */}
+                <div
+                    className={`${s.dot} rounded-full bg-page-admin animate-ping opacity-75`}
+                    style={{ animationDuration: "1s" }}
+                />
+            </div>
+
+            {/* Optional message */}
+            {message && (
+                <p className="text-sm text-muted-foreground mt-5 tracking-wide animate-pulse">
+                    {message}
+                </p>
+            )}
+        </div>
+    );
+};
+
+export default LoadingSpinner;

--- a/frontend/CareConnect/src/hooks/useAdminMetrics.js
+++ b/frontend/CareConnect/src/hooks/useAdminMetrics.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { adminService } from "../services/adminService";
+import { handleError } from "../utils/handleError";
+
+/**
+ * useAdminMetrics – fetches admin dashboard metrics on mount.
+ * Manages loading and error state internally.
+ * No render logic.
+ *
+ * @returns {{ metrics: object|null, loading: boolean }}
+ */
+export const useAdminMetrics = () => {
+    const [metrics, setMetrics] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchMetrics = async () => {
+            try {
+                const data = await adminService.getMetrics();
+                setMetrics(data);
+            } catch (error) {
+                handleError(error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchMetrics();
+    }, []);
+
+    return { metrics, loading };
+};

--- a/frontend/CareConnect/src/pages/admin/AdminHome.jsx
+++ b/frontend/CareConnect/src/pages/admin/AdminHome.jsx
@@ -1,58 +1,71 @@
-import { Users, Activity, UsersRound, FileText } from 'lucide-react';
+import { Users, Activity, UsersRound, FileText, CreditCard, CheckCircle } from 'lucide-react';
 import AdminLayout from './layouts/AdminLayout';
 import MetricCard from './components/MetricCard';
+import LoadingSpinner from '../../components/common/LoadingSpinner';
+import EmptyState from '../../components/common/EmptyState';
+import { useAdminMetrics } from '../../hooks/useAdminMetrics';
 
+/**
+ * AdminHome – Dashboard page for admin role.
+ * Only renders; all data logic lives in useAdminMetrics.
+ */
 const AdminHome = () => {
-    const metrics = [
-        {
-            id: 1,
-            title: 'Total Pacientes',
-            value: '4',
-            icon: <Users size={24} />,
-            iconBgClass: 'bg-page-admin',
-            iconColorClass: 'text-white'
-        },
-        {
-            id: 2,
-            title: 'Cuidadores Activos',
-            value: '4',
-            icon: <Activity size={24} />,
-            iconBgClass: 'bg-page-caregivers',
-            iconColorClass: 'text-white'
-        },
-        {
-            id: 3,
-            title: 'Familias registradas',
-            value: '4',
-            icon: <UsersRound size={24} />,
-            iconBgClass: 'bg-page-family',
-            iconColorClass: 'text-white'
-        },
-        {
-            id: 4,
-            title: 'Informes pendientes',
-            value: '4',
-            icon: <FileText size={24} />,
-            iconBgClass: 'bg-page-reports',
-            iconColorClass: 'text-white'
-        }
-    ];
+    const { metrics, loading } = useAdminMetrics();
 
     return (
         <AdminLayout activeItem="inicio">
-            {/* Metrics Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl ml-auto">
-                {metrics.map((metric) => (
+            {loading && <LoadingSpinner message="Cargando métricas..." size="lg" />}
+
+            {!loading && !metrics && (
+                <EmptyState message="No se pudieron cargar las métricas" />
+            )}
+
+            {!loading && metrics && (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl ml-auto">
                     <MetricCard
-                        key={metric.id}
-                        title={metric.title}
-                        value={metric.value}
-                        icon={metric.icon}
-                        iconBgClass={metric.iconBgClass}
-                        iconColorClass={metric.iconColorClass}
+                        title="Cuidadores activos"
+                        value={metrics.totalCaregivers}
+                        icon={<Activity size={24} />}
+                        iconBgClass="bg-page-caregivers"
+                        iconColorClass="text-white"
                     />
-                ))}
-            </div>
+                    <MetricCard
+                        title="Total Pacientes"
+                        value={metrics.totalPatients}
+                        icon={<Users size={24} />}
+                        iconBgClass="bg-page-admin"
+                        iconColorClass="text-white"
+                    />
+                    <MetricCard
+                        title="Familias registradas"
+                        value={metrics.totalFamilies}
+                        icon={<UsersRound size={24} />}
+                        iconBgClass="bg-page-family"
+                        iconColorClass="text-white"
+                    />
+                    <MetricCard
+                        title="Informes pendientes"
+                        value={metrics.pendingReports}
+                        icon={<FileText size={24} />}
+                        iconBgClass="bg-page-reports"
+                        iconColorClass="text-white"
+                    />
+                    <MetricCard
+                        title="Pagos pendientes"
+                        value={metrics.pendingPayments}
+                        icon={<CreditCard size={24} />}
+                        iconBgClass="bg-yellow-500"
+                        iconColorClass="text-white"
+                    />
+                    <MetricCard
+                        title="Pagos completados"
+                        value={metrics.completedPayments}
+                        icon={<CheckCircle size={24} />}
+                        iconBgClass="bg-green-500"
+                        iconColorClass="text-white"
+                    />
+                </div>
+            )}
         </AdminLayout>
     );
 };

--- a/frontend/CareConnect/src/services/adminService.js
+++ b/frontend/CareConnect/src/services/adminService.js
@@ -1,0 +1,53 @@
+// import { apiFetch } from "./api"; // Uncomment when api.js is ready
+
+/**
+ * adminService – Admin module endpoints.
+ * Only defines API calls; no state, no side effects, no notifications.
+ */
+export const adminService = {
+    /**
+     * Fetch global admin metrics.
+     * TODO: replace mock with apiFetch("/admin/metrics") when backend is ready.
+     * @returns {Promise<{
+     *   totalCaregivers: number,
+     *   totalPatients: number,
+     *   totalFamilies: number,
+     *   pendingReports: number,
+     *   pendingPayments: number,
+     *   completedPayments: number
+     * }>}
+     */
+    getMetrics: () => {
+        // TODO: replace with apiFetch("/admin/metrics") when backend is ready
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve({
+                    totalCaregivers: 12,
+                    totalPatients: 8,
+                    totalFamilies: 5,
+                    pendingReports: 3,
+                    pendingPayments: 4,
+                    completedPayments: 27,
+                });
+            }, 800);
+        });
+    },
+
+    // getCaregivers: () => apiFetch("/admin/caregivers"),
+
+    // createCaregiver: (data) =>
+    //   apiFetch("/admin/caregivers", { method: "POST", body: JSON.stringify(data) }),
+
+    // updateCaregiver: (id, data) =>
+    //   apiFetch(`/admin/caregivers/${id}`, { method: "PUT", body: JSON.stringify(data) }),
+
+    // deactivateCaregiver: (id) =>
+    //   apiFetch(`/admin/caregivers/${id}`, { method: "PATCH" }),
+
+    // getPatients: () => apiFetch("/admin/patients"),
+
+    // getPayments: () => apiFetch("/admin/payments"),
+
+    // executePayment: (id) =>
+    //   apiFetch(`/admin/payments/${id}/execute`, { method: "POST" }),
+};

--- a/frontend/CareConnect/src/services/adminService.js
+++ b/frontend/CareConnect/src/services/adminService.js
@@ -31,6 +31,7 @@ export const adminService = {
                 });
             }, 800);
         });
+        // return Promise.reject(new Error("test")); // Uncomment to test error handling
     },
 
     // getCaregivers: () => apiFetch("/admin/caregivers"),

--- a/frontend/CareConnect/src/utils/handleError.js
+++ b/frontend/CareConnect/src/utils/handleError.js
@@ -1,0 +1,14 @@
+import { toast } from "react-toastify";
+
+/**
+ * Centralized error handler for all API calls.
+ * Never exposes raw backend errors to the UI.
+ * @param {unknown} error - The caught error object.
+ * @param {string} [fallbackMessage] - Optional custom fallback message.
+ */
+export const handleError = (error, fallbackMessage = "Ocurrió un error inesperado") => {
+    const message =
+        error instanceof Error ? error.message : fallbackMessage;
+
+    toast.error(message);
+};


### PR DESCRIPTION
# 🔀 Pull Request – feat: Admin data flow para AdminHome (Dashboard)

---

## 🧩 ¿Qué se hizo?

Se implementó el flujo de datos completo para el módulo **AdminHome**:

- Se creó `services/adminService.js` con el método `getMetrics()` usando un mock temporal con latencia simulada (listo para reemplazar con `apiFetch("/admin/metrics")` cuando el backend esté disponible).
- Se creó `hooks/useAdminMetrics.js` que gestiona `loading`, `metrics` y el manejo de errores centralizados.
- Se refactorizó `AdminHome.jsx` para consumir únicamente el hook, sin lógica asíncrona en la Page.
- Se crearon los componentes de infraestructura comunes `LoadingSpinner.jsx` y `EmptyState.jsx`.
- Se implementó `ToastContainer` en `App.jsx` para habilitar notificaciones globales.
- Se creó `utils/handleError.js` como manejador centralizado de errores con `react-toastify`.

---

## 🖥️ Pantallas / Componentes afectados

* **Pantalla:** `pages/admin/AdminHome.jsx`
* **Hook nuevo:** `hooks/useAdminMetrics.js`
* **Service nuevo:** `services/adminService.js`
* **Componentes nuevos:** `components/common/LoadingSpinner.jsx`, `components/common/EmptyState.jsx`
* **Utilidad nueva:** `utils/handleError.js`
* **Modificación global:** `App.jsx` (se añadió `ToastContainer`)

---

## 📐 Arquitectura del flujo

```
AdminHome.jsx
   ↓ consume
useAdminMetrics.js
   ↓ llama
adminService.getMetrics()   ← mock temporal (800ms latencia)
   ↓ (futuro)
apiFetch("/admin/metrics")
   ↓
Backend
```

---

## 📊 Shape de datos (contrato con backend)

```js
{
  totalCaregivers: number,
  totalPatients: number,
  totalFamilies: number,
  pendingReports: number,
  pendingPayments: number,
  completedPayments: number
}
```

---

## 🧪 ¿Cómo probarlo?

1. Ir a la ruta del Dashboard Admin (rol `ADMIN`)
2. Verificar que el spinner aparece ~800ms durante la carga
3. Verificar que las 6 tarjetas de métricas se renderizan con valores del mock
4. Para probar el `EmptyState`: en `adminService.js`, hacer que `getMetrics()` rechace con `Promise.reject(new Error("test"))` → debe aparecer el toast de error y el estado vacío

---

## ⚠️ Consideraciones

* El endpoint `GET /admin/metrics` **todavía no existe en el backend**. El mock debe permanecer hasta que esté disponible.
* Para migrar a endpoint real, **solo modificar `adminService.js`** (una línea): reemplazar el `new Promise(...)` por `apiFetch("/admin/metrics")`. No tocar ni el hook ni la page.
* `handleError.js`, `LoadingSpinner.jsx` y `EmptyState.jsx` son compartidos y reutilizables por el resto del módulo Admin.

---

## ✅ Checklist

* [x] Probé la funcionalidad localmente
* [x] No rompí otras pantallas
* [x] El PR es solo de esta feature
* [x] El código es legible y ordenado
* [x] La Page no contiene lógica asíncrona
* [x] El hook no contiene lógica de render
* [x] El service no usa estado ni hooks de React
* [x] Los errores se manejan con `handleError` (nunca expuestos crudos)
* [x] Se muestra `LoadingSpinner` durante la carga
* [x] Se muestra `EmptyState` si `metrics === null`

---