### PR TITLE
feat: Admin data flow para AdminHome

### DIFF
--- a/frontend/CareConnect/src/hooks/useCaregivers.js
+++ b/frontend/CareConnect/src/hooks/useCaregivers.js
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from "react";
+import { adminService } from "../services/adminService";
+import { handleError } from "../utils/handleError";
+
+/**
+ * useCaregivers – manages server state for the Admin Caregivers view.
+ *
+ * Responsibilities:
+ *  - Fetch caregivers on mount.
+ *  - Expose loading state.
+ *  - Provide mutation handlers (create, update, deactivate).
+ *  - After every mutation → refetch (source of truth is always the service).
+ *
+ * Does NOT:
+ *  - Manipulate arrays manually.
+ *  - Unify data from multiple tables (that's the service's job).
+ *  - Use Zustand.
+ *  - Perform async operations outside this hook (Page stays clean).
+ *
+ * @returns {{
+ *   caregivers: Array<{ id: string, fullName: string, dni: string, cbu: string, workedHours: number }>,
+ *   loading: boolean,
+ *   createCaregiver: (data: object) => Promise<void>,
+ *   updateCaregiver: (id: string, data: object) => Promise<void>,
+ *   deactivateCaregiver: (id: string) => Promise<void>,
+ *   refetch: () => Promise<void>
+ * }}
+ */
+export const useCaregivers = () => {
+    const [caregivers, setCaregivers] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    // Core fetch – always pulls from the service, never patches local state.
+    const fetchCaregivers = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = await adminService.getCaregivers();
+            setCaregivers(data);
+        } catch (error) {
+            handleError(error);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    // Fetch on mount
+    useEffect(() => {
+        fetchCaregivers();
+    }, [fetchCaregivers]);
+
+    /**
+     * Create a new caregiver and refresh the list.
+     * @param {{ fullName: string, dni: string, cbu: string }} formData
+     */
+    const createCaregiver = async (formData) => {
+        try {
+            await adminService.createCaregiver(formData);
+            await fetchCaregivers();
+        } catch (error) {
+            handleError(error);
+        }
+    };
+
+    /**
+     * Update an existing caregiver and refresh the list.
+     * @param {string} id
+     * @param {{ fullName?: string, dni?: string, cbu?: string }} formData
+     */
+    const updateCaregiver = async (id, formData) => {
+        try {
+            await adminService.updateCaregiver(id, formData);
+            await fetchCaregivers();
+        } catch (error) {
+            handleError(error);
+        }
+    };
+
+    /**
+     * Deactivate a caregiver and refresh the list.
+     * @param {string} id
+     */
+    const deactivateCaregiver = async (id) => {
+        try {
+            await adminService.deactivateCaregiver(id);
+            await fetchCaregivers();
+        } catch (error) {
+            handleError(error);
+        }
+    };
+
+    return {
+        caregivers,
+        loading,
+        createCaregiver,
+        updateCaregiver,
+        deactivateCaregiver,
+        refetch: fetchCaregivers,
+    };
+};

--- a/frontend/CareConnect/src/pages/admin/AdminCaregivers.jsx
+++ b/frontend/CareConnect/src/pages/admin/AdminCaregivers.jsx
@@ -1,32 +1,69 @@
 import { useState } from 'react';
-import { Plus, Search, Edit2, Ban, Trash2, CreditCard } from 'lucide-react';
-import AdminLayout from './layouts/AdminLayout';
+import { Plus, Search, Edit2, Ban, CreditCard } from 'lucide-react';
 import Button from '../../components/common/Button';
 import Table from '../../components/common/Table';
+import LoadingSpinner from '../../components/common/LoadingSpinner';
+import EmptyState from '../../components/common/EmptyState';
+import { useCaregivers } from '../../hooks/useCaregivers';
 
-// Dummy data for caregivers
-const caregiversData = [
-    { id: 1, name: 'Pedro Martinez', dni: '25123456', cbu_cvu: '0000003100012345678901', hoursWorked: 45, status: 'Activo' },
-    { id: 2, name: 'Ana Garcia', dni: '28654321', cbu_cvu: '0000003100098765432109', hoursWorked: 32, status: 'Activo' },
-    { id: 3, name: 'Lucas Rodriguez', dni: '30987654', cbu_cvu: '0000003100045612378904', hoursWorked: 0, status: 'Inactivo' },
-    { id: 4, name: 'Maria Lopez', dni: '22111222', cbu_cvu: '0000003100078945612307', hoursWorked: 50, status: 'Activo' },
-];
-
+/**
+ * AdminCaregivers – Admin view for managing caregivers.
+ *
+ * Responsibilities:
+ *  - Render the caregivers list via the Table component.
+ *  - Show LoadingSpinner while data is being fetched.
+ *  - Show EmptyState if the list is empty.
+ *  - Delegate all async logic to useCaregivers.
+ *
+ * Does NOT:
+ *  - Call the service directly.
+ *  - Manipulate caregiver arrays.
+ *  - Contain any async logic.
+ */
 const AdminCaregivers = () => {
+    // ── Server state via hook ──────────────────────────────────────────────
+    const {
+        caregivers,
+        loading,
+        createCaregiver,
+        updateCaregiver,
+        deactivateCaregiver,
+    } = useCaregivers();
+
+    // ── Local UI state ─────────────────────────────────────────────────────
     const [selectedFilter, setSelectedFilter] = useState('Todos');
+    const [searchQuery, setSearchQuery] = useState('');
 
     const filters = ['Todos', 'Activos', 'Inactivos'];
 
-    const handlePay = (caregiver) => {
-        console.log(`Paying to ${caregiver.name}`);
-        // Logic for payment modal or action
+    // ── Action handlers – delegate to hook, no inline async ───────────────
+    const handleCreate = () => {
+        // TODO: open create modal, then call createCaregiver(formData)
+        console.log('Open create caregiver modal');
     };
 
+    const handleEdit = (caregiver, closeMenu) => {
+        closeMenu();
+        // TODO: open edit modal pre-filled with caregiver data, then call updateCaregiver(caregiver.id, formData)
+        console.log('Edit caregiver:', caregiver.id);
+    };
+
+    const handleDeactivate = (caregiver, closeMenu) => {
+        closeMenu();
+        deactivateCaregiver(caregiver.id);
+    };
+
+    const handlePay = (caregiver) => {
+        // TODO: trigger payment flow via adminService.executePayment (future)
+        console.log('Pay caregiver:', caregiver.id);
+    };
+
+    // ── Table column definitions ───────────────────────────────────────────
     const columns = [
         {
             header: 'Nombre',
-            accessor: 'name',
-            cellClassName: 'font-body text-f-primary font-bold'
+            accessor: 'fullName',
+            cellClassName: 'font-body text-f-primary font-bold',
         },
         {
             header: 'DNI',
@@ -34,18 +71,18 @@ const AdminCaregivers = () => {
         },
         {
             header: 'CBU/CVU',
-            accessor: 'cbu_cvu',
-            cellClassName: 'font-mono text-sm'
+            accessor: 'cbu',
+            cellClassName: 'font-mono text-sm',
         },
         {
             header: 'Horas Trabajadas',
-            accessor: 'hoursWorked',
+            accessor: 'workedHours',
             cellClassName: 'text-center',
             render: (row) => (
                 <span className="font-semibold text-f-primary">
-                    {row.hoursWorked} hs
+                    {row.workedHours} hs
                 </span>
-            )
+            ),
         },
         {
             header: 'Pago',
@@ -57,41 +94,36 @@ const AdminCaregivers = () => {
                         handlePay(row);
                     }}
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-green-50 text-green-700 hover:bg-green-100 transition-colors border border-green-200"
-                    disabled={row.hoursWorked === 0}
+                    disabled={row.workedHours === 0}
                 >
                     <CreditCard size={14} />
                     Pagar
                 </button>
-            )
-        }
+            ),
+        },
     ];
 
+    // ── Row action menu ────────────────────────────────────────────────────
     const renderActions = (caregiver, closeMenu) => (
         <>
             <button
-                onClick={() => { console.log('Edit', caregiver); closeMenu(); }}
+                onClick={() => handleEdit(caregiver, closeMenu)}
                 className="w-full px-4 py-3 text-left text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
             >
                 <Edit2 size={16} />
                 Editar
             </button>
             <button
-                onClick={() => { console.log('Deactivate', caregiver); closeMenu(); }}
+                onClick={() => handleDeactivate(caregiver, closeMenu)}
                 className="w-full px-4 py-3 text-left text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
             >
                 <Ban size={16} />
                 Desactivar
             </button>
-            <button
-                onClick={() => { console.log('Delete', caregiver); closeMenu(); }}
-                className="w-full px-4 py-3 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
-            >
-                <Trash2 size={16} />
-                Eliminar
-            </button>
         </>
     );
 
+    // ── Render ─────────────────────────────────────────────────────────────
     return (
         
             <div className="max-w-6xl ml-auto mr-auto">
@@ -103,6 +135,7 @@ const AdminCaregivers = () => {
                         variant="admin"
                         icon={<Plus size={20} />}
                         className="h-10 truncate"
+                        onClick={handleCreate}
                     >
                         Agregar Cuidador
                     </Button>
@@ -117,8 +150,8 @@ const AdminCaregivers = () => {
                                 key={filter}
                                 onClick={() => setSelectedFilter(filter)}
                                 className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${selectedFilter === filter
-                                    ? 'bg-white text-f-primary shadow-sm border border-gray-200'
-                                    : 'bg-transparent text-f-secondary hover:text-f-primary hover:bg-gray-100'
+                                        ? 'bg-white text-f-primary shadow-sm border border-gray-200'
+                                        : 'bg-transparent text-f-secondary hover:text-f-primary hover:bg-gray-100'
                                     }`}
                             >
                                 {filter}
@@ -132,17 +165,25 @@ const AdminCaregivers = () => {
                         <input
                             type="text"
                             placeholder="Buscar cuidador..."
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
                             className="pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-full focus:outline-none focus:ring-2 focus:ring-page-admin w-64"
                         />
                     </div>
                 </div>
 
-                {/* Caregivers Table */}
-                <Table
-                    columns={columns}
-                    data={caregiversData}
-                    renderActions={renderActions}
-                />
+                {/* Content: Spinner → EmptyState → Table */}
+                {loading ? (
+                    <LoadingSpinner message="Cargando cuidadores..." />
+                ) : caregivers.length === 0 ? (
+                    <EmptyState message="No hay cuidadores registrados." />
+                ) : (
+                    <Table
+                        columns={columns}
+                        data={caregivers}
+                        renderActions={renderActions}
+                    />
+                )}
             </div>
         
     );

--- a/frontend/CareConnect/src/services/adminService.js
+++ b/frontend/CareConnect/src/services/adminService.js
@@ -4,6 +4,29 @@
  * adminService – Admin module endpoints.
  * Only defines API calls; no state, no side effects, no notifications.
  */
+
+// ---------------------------------------------------------------------------
+// Internal mock data – simulates two separate DB tables.
+// These mocks live ONLY in the service layer.
+// The Page and the Hook must never know about this separation.
+// ---------------------------------------------------------------------------
+
+/** Mock: Table 1 – caregiver base data (fullName, dni, cbu) */
+const mockCaregiversBase = [
+    { id: "c1", fullName: "Pedro Martinez", dni: "25123456", cbu: "0000003100012345678901" },
+    { id: "c2", fullName: "Ana Garcia", dni: "28654321", cbu: "0000003100098765432109" },
+    { id: "c3", fullName: "Lucas Rodriguez", dni: "30987654", cbu: "0000003100045612378904" },
+    { id: "c4", fullName: "Maria Lopez", dni: "22111222", cbu: "0000003100078945612307" },
+];
+
+/** Mock: Table 2 – worked hours per caregiver (keyed by caregiver id) */
+const mockWorkedHours = {
+    c1: 45,
+    c2: 32,
+    c3: 0,
+    c4: 50,
+};
+
 export const adminService = {
     /**
      * Fetch global admin metrics.
@@ -31,19 +54,74 @@ export const adminService = {
                 });
             }, 800);
         });
-        // return Promise.reject(new Error("test")); // Uncomment to test error handling
     },
 
-    // getCaregivers: () => apiFetch("/admin/caregivers"),
+    /**
+     * Fetch all caregivers.
+     * Merges base data (Table 1) with worked hours (Table 2) before returning.
+     * TODO: replace with apiFetch("/admin/caregivers") when backend is ready.
+     * @returns {Promise<Array<{ id: string, fullName: string, dni: string, cbu: string, workedHours: number }>>}
+     */
+    getCaregivers: () => {
+        // TODO: replace with apiFetch("/admin/caregivers") when backend is ready
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                // Merge: join the two mock tables on caregiver id
+                const unified = mockCaregiversBase.map((caregiver) => ({
+                    ...caregiver,
+                    workedHours: mockWorkedHours[caregiver.id] ?? 0,
+                }));
+                resolve(unified);
+            }, 800);
+        });
+    },
 
-    // createCaregiver: (data) =>
-    //   apiFetch("/admin/caregivers", { method: "POST", body: JSON.stringify(data) }),
+    /**
+     * Create a new caregiver.
+     * TODO: replace with apiFetch("/admin/caregivers", { method: "POST", body: JSON.stringify(data) })
+     * @param {{ fullName: string, dni: string, cbu: string }} data
+     * @returns {Promise<void>}
+     */
+    createCaregiver: (data) => {
+        // TODO: replace with apiFetch("/admin/caregivers", { method: "POST", body: JSON.stringify(data) })
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                // In real impl, backend handles persistence; mock just resolves
+                resolve();
+            }, 600);
+        });
+    },
 
-    // updateCaregiver: (id, data) =>
-    //   apiFetch(`/admin/caregivers/${id}`, { method: "PUT", body: JSON.stringify(data) }),
+    /**
+     * Update an existing caregiver.
+     * TODO: replace with apiFetch(`/admin/caregivers/${id}`, { method: "PUT", body: JSON.stringify(data) })
+     * @param {string} id
+     * @param {{ fullName?: string, dni?: string, cbu?: string }} data
+     * @returns {Promise<void>}
+     */
+    updateCaregiver: (id, data) => {
+        // TODO: replace with apiFetch(`/admin/caregivers/${id}`, { method: "PUT", body: JSON.stringify(data) })
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, 600);
+        });
+    },
 
-    // deactivateCaregiver: (id) =>
-    //   apiFetch(`/admin/caregivers/${id}`, { method: "PATCH" }),
+    /**
+     * Deactivate a caregiver (soft delete / status change).
+     * TODO: replace with apiFetch(`/admin/caregivers/${id}`, { method: "PATCH" })
+     * @param {string} id
+     * @returns {Promise<void>}
+     */
+    deactivateCaregiver: (id) => {
+        // TODO: replace with apiFetch(`/admin/caregivers/${id}`, { method: "PATCH" })
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, 600);
+        });
+    },
 
     // getPatients: () => apiFetch("/admin/patients"),
 


### PR DESCRIPTION
# 🔀 Pull Request – feat: Admin data flow para AdminCaregivers

---

## 🧩 ¿Qué se hizo?

Se implementó el flujo de datos completo para el módulo **AdminCaregivers**:

- Se agregaron a `services/adminService.js` los métodos `getCaregivers()`, `createCaregiver(data)`, `updateCaregiver(id, data)` y `deactivateCaregiver(id)` con mocks temporales que simulan la separación de tablas del backend (datos base + horas trabajadas), unificadas internamente antes de resolver.
- Se creó `hooks/useCaregivers.js` que gestiona `caregivers`, `loading`, todas las mutaciones y el refetch automático post-mutación.
- Se refactorizó `pages/admin/AdminCaregivers.jsx` para consumir únicamente el hook, eliminando todos los datos hardcodeados y la lógica asíncrona de la Page.

---

## 🖥️ Pantallas / Componentes afectados

* **Pantalla:** `pages/admin/AdminCaregivers.jsx`
* **Hook nuevo:** `hooks/useCaregivers.js`
* **Service modificado:** `services/adminService.js` (se añadieron los 4 métodos de cuidadores)

---

## 📐 Arquitectura del flujo

```
AdminCaregivers.jsx
   ↓ consume
useCaregivers.js
   ↓ llama
adminService.getCaregivers()   ← mock temporal (merge de 2 tablas, 800ms)
   ↓ (futuro)
apiFetch("/admin/caregivers")
   ↓
Backend
```

---

## 📊 Shape de datos unificado (contrato con backend)

```js
// Modelo que devuelve getCaregivers() ya unificado:
{
  id: string,
  fullName: string,
  dni: string,
  cbu: string,
  workedHours: number
}

```

---

## 🧪 ¿Cómo probarlo?

1. Navegar a la ruta de Cuidadores (rol `ADMIN`)
2. Verificar que el spinner aparece ~800ms durante la carga inicial
3. Verificar que la tabla muestra las columnas: **Nombre, DNI, CBU/CVU, Horas Trabajadas, Pago**
4. Verificar que el botón **Pagar** está deshabilitado si `workedHours === 0` (Lucas Rodriguez)
5. Hacer click en el menú de acciones de una fila → verificar **Editar** y **Desactivar** disponibles
6. Para probar `EmptyState`: vaciar `mockCaregiversBase` en `adminService.js` → debe aparecer el estado vacío en lugar de la tabla
7. Para probar el toast de error: hacer que `getCaregivers()` rechace con `Promise.reject(new Error("test"))` → debe mostrarse el toast

---

## ⚠️ Consideraciones

* Los endpoints `GET/POST/PUT/PATCH /admin/caregivers` **no existen en el backend todavía**. Los mocks deben permanecer hasta que estén disponibles.
* Para migrar a endpoints reales, **solo modificar `adminService.js`**: reemplazar el `new Promise(...)` de cada método por el `apiFetch(...)` correspondiente. No tocar el hook ni la Page.
* Los datos del backend real vendrán de **dos tablas separadas**; la lógica de merge debe mantenerse en el service (no en el hook ni en la Page).
* Los handlers `handleCreate` y `handleEdit` en la Page tienen `TODO` pendientes para cuando se implementen los modales de formulario.

---

## ✅ Checklist

* [x] Probé la funcionalidad localmente
* [x] No rompí otras pantallas
* [x] El PR es solo de esta feature
* [x] El código es legible y ordenado
* [x] La Page no contiene lógica asíncrona
* [x] El hook no contiene lógica de render
* [x] El service no usa estado ni hooks de React
* [x] Los errores se manejan con `handleError` (nunca expuestos crudos)
* [x] Se muestra `LoadingSpinner` durante la carga
* [x] Se muestra `EmptyState` si la lista está vacía
* [x] Después de cada mutación se ejecuta `fetchCaregivers()` (regla de oro del data flow)
* [x] El merge de tablas vive únicamente en el service

---