### PR TITLE
Feature/frontend fetch users to admin

### DIFF
--- a/frontend/CareConnect/src/hooks/useCaregivers.js
+++ b/frontend/CareConnect/src/hooks/useCaregivers.js
@@ -18,13 +18,15 @@ import { handleError } from "../utils/handleError";
  *  - Perform async operations outside this hook (Page stays clean).
  *
  * @returns {{
- *   caregivers: Array<{ id: string, fullName: string, dni: string, cbu: string, workedHours: number }>,
+ *   caregivers: Array<{ id: string, fullName: string, dni: string, cbu: string, workedHours: number, status: string }>,
  *   loading: boolean,
  *   createCaregiver: (data: object) => Promise<void>,
  *   updateCaregiver: (id: string, data: object) => Promise<void>,
  *   deactivateCaregiver: (id: string) => Promise<void>,
  *   refetch: () => Promise<void>
  * }}
+ * @note `cbu` defaults to "-" and `workedHours` to 0 since the GET /api/v1/admin/caregiver
+ *       endpoint does not return those fields currently.
  */
 export const useCaregivers = () => {
     const [caregivers, setCaregivers] = useState([]);

--- a/frontend/CareConnect/src/hooks/usePatients.js
+++ b/frontend/CareConnect/src/hooks/usePatients.js
@@ -17,11 +17,11 @@ import { handleError } from "../utils/handleError";
  *  - Perform async operations outside this hook (Page stays clean).
  *
  * @returns {{
- *   patients: Array<{ id: string, fullName: string, age: number, dni: string, representative: string, status: string }>,
+ *   patients: Array<{ id: number, fullName: string, age: number|string, dni: string, representative: string, status: string }>,
  *   loading: boolean,
  *   createPatient: (data: object) => Promise<void>,
- *   updatePatient: (id: string, data: object) => Promise<void>,
- *   deactivatePatient: (id: string) => Promise<void>,
+ *   updatePatient: (id: number, data: object) => Promise<void>,
+ *   deactivatePatient: (id: number) => Promise<void>,
  *   refetch: () => Promise<void>
  * }}
  */

--- a/frontend/CareConnect/src/hooks/useUsers.js
+++ b/frontend/CareConnect/src/hooks/useUsers.js
@@ -17,7 +17,7 @@ import { handleError } from "../utils/handleError";
  *  - Perform async operations outside this hook (Page stays clean).
  *
  * @returns {{
- *   users: Array<{ id: string, name: string, email: string, role: string, status: string }>,
+ *   users: Array<{ id: string, name: string, email: string, role: 'Admin'|'Cuidador'|'Paciente', status: string }>,
  *   loading: boolean,
  *   createUser: (data: object) => Promise<void>,
  *   updateUser: (id: string, data: object) => Promise<void>,

--- a/frontend/CareConnect/src/pages/admin/AdminPatients.jsx
+++ b/frontend/CareConnect/src/pages/admin/AdminPatients.jsx
@@ -39,7 +39,7 @@ const AdminPatients = () => {
         const matchesSearch =
             !query ||
             p.fullName.toLowerCase().includes(query) ||
-            p.dni.includes(query);
+            (p.email && p.email.toLowerCase().includes(query));
 
         return matchesFilter && matchesSearch;
     });
@@ -54,17 +54,13 @@ const AdminPatients = () => {
             cellClassName: 'font-body text-f-primary font-bold',
         },
         {
-            header: 'Edad',
-            accessor: 'age',
+            header: 'Email',
+            accessor: 'email',
         },
         {
-            header: 'DNI',
-            accessor: 'dni',
-        },
-        {
-            header: 'Representante',
-            accessor: 'representative',
-            render: (row) => row.representative || '-',
+            header: 'Teléfono',
+            accessor: 'phone',
+            render: (row) => row.phone || '-',
         },
         {
             header: 'Estado',

--- a/frontend/CareConnect/src/pages/admin/AdminUsers.jsx
+++ b/frontend/CareConnect/src/pages/admin/AdminUsers.jsx
@@ -23,7 +23,7 @@ const AdminUsers = () => {
         password: ''
     });
 
-    const filters = ['Todos', 'Cuidadores', 'Pacientes', 'Familia'];
+    const filters = ['Todos', 'Admin', 'Cuidadores', 'Pacientes'];
 
     // -----------------------------------------------------------------
     // Derived list: filter by role pill + search input
@@ -31,9 +31,9 @@ const AdminUsers = () => {
     const filteredUsers = users.filter((user) => {
         const matchesFilter =
             selectedFilter === 'Todos' ||
+            (selectedFilter === 'Admin' && user.role === 'Admin') ||
             (selectedFilter === 'Cuidadores' && user.role === 'Cuidador') ||
-            (selectedFilter === 'Pacientes' && user.role === 'Paciente') ||
-            (selectedFilter === 'Familia' && user.role === 'Familia');
+            (selectedFilter === 'Pacientes' && user.role === 'Paciente');
 
         const query = searchQuery.toLowerCase();
         const matchesSearch =

--- a/frontend/CareConnect/src/services/adminService.js
+++ b/frontend/CareConnect/src/services/adminService.js
@@ -6,31 +6,59 @@ import { apiFetch } from "./api";
  */
 
 // ---------------------------------------------------------------------------
-// Internal mock data – simulates two separate DB tables.
-// These mocks live ONLY in the service layer.
-// The Page and the Hook must never know about this separation.
-// ---------------------------------------------------------------------------
-
-/** Mock: Table 1 – caregiver base data (fullName, dni, cbu) */
-const mockCaregiversBase = [
-    { id: "c1", fullName: "Pedro Martinez", dni: "25123456", cbu: "0000003100012345678901", status: "Activo" },
-    { id: "c2", fullName: "Ana Garcia", dni: "28654321", cbu: "0000003100098765432109", status: "Activo" },
-    { id: "c3", fullName: "Lucas Rodriguez", dni: "30987654", cbu: "0000003100045612378904", status: "Inactivo" },
-    { id: "c4", fullName: "Maria Lopez", dni: "22111222", cbu: "0000003100078945612307", status: "Activo" },
-];
-
-/** Mock: Table 2 – worked hours per caregiver (keyed by caregiver id) */
-const mockWorkedHours = {
-    c1: 45,
-    c2: 32,
-    c3: 0,
-    c4: 50,
-};
-
-// ---------------------------------------------------------------------------
 // Helpers – transform backend shapes into frontend shapes.
 // These transformations live ONLY in the service layer.
 // ---------------------------------------------------------------------------
+
+/**
+ * Calculate age in years from an ISO date string (YYYY-MM-DD).
+ * @param {string|null} birthDate
+ * @returns {number|string}
+ */
+const calcAge = (birthDate) => {
+    if (!birthDate) return "-";
+    const today = new Date();
+    const birth = new Date(birthDate);
+    let age = today.getFullYear() - birth.getFullYear();
+    const m = today.getMonth() - birth.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+    return age;
+};
+
+/**
+ * Transform a backend caregiver (GET /api/v1/admin/caregiver) into the frontend shape.
+ * Note: CBU and workedHours are not returned by the GET endpoint yet.
+ * @param {Object} c - Raw caregiver from backend.
+ * @returns {{ id: string, fullName: string, dni: string, cbu: string, workedHours: number, status: string }}
+ */
+const transformCaregiver = (c) => ({
+    id: c.caregiverDni ?? String(Math.random()),
+    fullName: `${c.firstName} ${c.lastName}`.trim(),
+    dni: c.caregiverDni ?? "-",
+    // billingInformation does not include CBU/CVU in current GET response
+    cbu: c.billingInformation?.cbu ?? "-",
+    // workedHours is not yet returned by this endpoint
+    workedHours: c.workedHours ?? 0,
+    status: c.caregiverStatus ?? "Activo",
+});
+
+/**
+ * Transform a backend patient (GET /api/v1/admin/patient) into the frontend shape.
+ * @param {Object} p - Raw patient from backend.
+ * @returns {{ id: number, fullName: string, age: number|string, dni: string, representative: string, status: string }}
+ */
+const transformPatient = (p) => {
+    return {
+        id: p.patientId,
+        fullName: `${p.firstName} ${p.lastName}`.trim(),
+        age: calcAge(p.birthDate),
+        email: p.email ?? "-",
+        phone: p.phoneNumber ?? "-",
+        status: p.patientStatus ?? "Activo",
+    };
+};
+
+
 
 /**
  * Transform a backend CaregiverReportResponse into the frontend report shape.
@@ -100,23 +128,12 @@ export const adminService = {
     // ---------------------------------------------------------------------------
 
     /**
-     * Fetch all caregivers.
-     * Merges base data (Table 1) with worked hours (Table 2) before returning.
-     * TODO: replace with apiFetch("/admin/caregivers") when backend is ready.
-     * @returns {Promise<Array<{ id: string, fullName: string, dni: string, cbu: string, workedHours: number }>>}
+     * Fetch all caregivers from the backend.
+     * @returns {Promise<Array<{ id: string, fullName: string, dni: string, cbu: string, workedHours: number, status: string }>>}
      */
-    getCaregivers: () => {
-        // TODO: replace with apiFetch("/admin/caregivers") when backend is ready
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                // Merge: join the two mock tables on caregiver id
-                const unified = mockCaregiversBase.map((caregiver) => ({
-                    ...caregiver,
-                    workedHours: mockWorkedHours[caregiver.id] ?? 0,
-                }));
-                resolve(unified);
-            }, 800);
-        });
+    getCaregivers: async () => {
+        const raw = await apiFetch("/api/v1/admin/caregiver");
+        return raw.map(transformCaregiver);
     },
 
     /**
@@ -171,22 +188,12 @@ export const adminService = {
     // ---------------------------------------------------------------------------
 
     /**
-     * Fetch all patients.
-     * TODO: replace mock with apiFetch("/admin/patients") when backend is ready.
-     * @returns {Promise<Array<{ id: string, fullName: string, age: number, dni: string, representative: string, status: string }>>}
+     * Fetch all patients from the backend.
+     * @returns {Promise<Array<{ id: number, fullName: string, age: number|string, dni: string, representative: string, status: string }>>}
      */
-    getPatients: () => {
-        // TODO: replace with apiFetch("/admin/patients") when backend is ready
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve([
-                    { id: "p1", fullName: "Roberto Gómez", age: 75, dni: "12345678", representative: "Mariana Pérez", status: "Activo" },
-                    { id: "p2", fullName: "Laura Martinez", age: 68, dni: "23456789", representative: "-", status: "Activo" },
-                    { id: "p3", fullName: "Carlos López", age: 82, dni: "34567890", representative: "Juan Carlos", status: "Inactivo" },
-                    { id: "p4", fullName: "Ana Rodríguez", age: 71, dni: "45678901", representative: "-", status: "Activo" },
-                ]);
-            }, 800);
-        });
+    getPatients: async () => {
+        const raw = await apiFetch("/api/v1/admin/patient");
+        return raw.map(transformPatient);
     },
 
     /**

--- a/frontend/CareConnect/src/services/adminService.js
+++ b/frontend/CareConnect/src/services/adminService.js
@@ -290,26 +290,61 @@ export const adminService = {
     },
 
     // ---------------------------------------------------------------------------
-    // Users
+    // Users – aggregates Admins + Caregivers + Patients into one unified list.
     // ---------------------------------------------------------------------------
 
     /**
-     * Fetch all users.
-     * TODO: replace mock with apiFetch("/admin/users") when backend is ready.
+     * Fetch all users by merging three backend endpoints in parallel.
+     * Normalizes each backend shape into { id, name, email, role, status }.
+     *
+     * Sources:
+     *  - GET /api/v1/admin/me          → role "Admin"
+     *  - GET /api/v1/admin/caregiver   → role "Cuidador"
+     *  - GET /api/v1/admin/patient     → role "Paciente"
+     *
      * @returns {Promise<Array<{ id: string, name: string, email: string, role: string, status: string }>>}
      */
-    getUsers: () => {
-        // TODO: replace with apiFetch("/admin/users") when backend is ready
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve([
-                    { id: "u1", name: "Pablo", email: "pablo@gmail.com", role: "Cuidador", status: "Activo" },
-                    { id: "u2", name: "Juan", email: "juan@gmail.com", role: "Admin", status: "Activo" },
-                    { id: "u3", name: "Maria", email: "maria@gmail.com", role: "Familia", status: "Inactivo" },
-                    { id: "u4", name: "Pedro", email: "pedro@gmail.com", role: "Cuidador", status: "Activo" },
-                ]);
-            }, 800);
+    getUsers: async () => {
+        const [admins, caregivers, patients] = await Promise.all([
+            apiFetch("/api/v1/admin/me"),
+            apiFetch("/api/v1/admin/caregiver"),
+            apiFetch("/api/v1/admin/patient"),
+        ]);
+
+        /** @param {Object} a - Raw admin object from backend */
+        const transformAdmin = (a, index) => ({
+            id: `admin-${index}`,
+            name: `${a.firstName} ${a.lastName}`.trim(),
+            email: a.email,
+            role: "Admin",
+            status: "Activo",
         });
+
+        /** @param {Object} c - Raw caregiver object from backend */
+        const transformCaregiver = (c) => ({
+            id: `cg-${c.caregiverDni}`,
+            name: `${c.firstName} ${c.lastName}`.trim(),
+            email: c.email,
+            role: "Cuidador",
+            // caregiverStatus is not returned by GET, default to Activo
+            status: c.caregiverStatus ?? "Activo",
+        });
+
+        /** @param {Object} p - Raw patient object from backend */
+        const transformPatient = (p) => ({
+            id: `p-${p.patientId}`,
+            name: `${p.firstName} ${p.lastName}`.trim(),
+            email: p.email,
+            role: "Paciente",
+            // patientStatus is not returned by GET, default to Activo
+            status: p.patientStatus ?? "Activo",
+        });
+
+        return [
+            ...admins.map(transformAdmin),
+            ...caregivers.map(transformCaregiver),
+            ...patients.map(transformPatient),
+        ];
     },
 
     /**


### PR DESCRIPTION
# 🔀 Pull Request Template – Frontend

Usar este template para **todos los Pull Requests del equipo frontend**.

---

## 🧩 ¿Qué se hizo?

* **Integración AdminUsers → Backend:** 3 fetches en paralelo (`/me`, `/caregiver`, `/patient`) con normalización de roles (Admin, Cuidador, Paciente).
* **Integración AdminCaregivers → Backend:** `GET /api/v1/admin/caregiver` reemplaza mock. Helper `transformCaregiver` normaliza al shape `{ id, fullName, dni, cbu, workedHours, status }`.
* **Integración AdminPatients → Backend:** `GET /api/v1/admin/patient` reemplaza mock. Helper `transformPatient` normaliza al shape `{ id, fullName, age, email, phone, status }`.
* **Columnas ajustadas en AdminPatients:** `DNI` y `Representante` (no disponibles en el GET) reemplazadas por `Email` y `Teléfono`.
* **Helpers nuevos en `adminService.js`:** `transformCaregiver`, `transformPatient`, `calcAge` (calcula edad desde `birthDate`).
* **Documentación:** `backend_get_endpoints.md` actualizado con la sección completa de ABMs (`/admin/me`, `/admin/caregiver`, `/admin/patient`, `/admin/guardian`) y ejemplos de Postman para cada POST.

---

## 🖥️ Pantallas / Componentes afectados

* **Pantallas:** `AdminUsers.jsx`, `AdminCaregivers.jsx`, `AdminPatients.jsx`
* **Servicio:** `adminService.js` (reemplazados todos los mocks de usuarios, cuidadores y pacientes)
* **Hooks:** `useUsers.js`, `useCaregivers.js`, `usePatients.js` (solo JSDoc actualizado)
* **Documentación:** `backend_get_endpoints.md`

---

## 🧪 ¿Cómo probarlo?

1. Levantar el backend en el puerto `8080`.
2. Iniciar el frontend (`npm run dev`).
3. Navegar a **Administración > Usuarios** → verificar tabla con roles Admin/Cuidador/Paciente y filtros funcionando.
4. Navegar a **Administración > Cuidadores** → verificar tabla con datos reales (DNI, nombre, estado).
5. Navegar a **Administración > Pacientes** → verificar tabla con Email y Teléfono reales.
6. Probar la barra de búsqueda en cada sección.

---

## 📸 Capturas (si aplica)

*(Screenshots de las tres tablas con datos reales)*

---

## ⚠️ Consideraciones

* `status` se inicializa como `"Activo"` por defecto ya que no viene en el `GET` de algunos endpoints.
* `cbu` y `workedHours` de cuidadores aparecen como `"-"` y `0` hasta que el backend los exponga en el GET.
* `patientDni` no se expone en el GET de pacientes; se reemplazó por `email` y `phoneNumber`.
* Todas las pantallas requieren backend activo. Si está caído: toast de error vía `handleError.js`.

---

## ✅ Checklist

* [x] Probé la funcionalidad localmente
* [x] No rompí otras pantallas
* [x] El PR es solo de esta feature
* [x] El código es legible y ordenado

---